### PR TITLE
Add 'from' header usage instead of messageID for filename

### DIFF
--- a/src/email.ts
+++ b/src/email.ts
@@ -20,7 +20,8 @@ export async function email(message: any, env: any, ctx?: any): Promise<void> {
     if (!url) throw new Error('Missing WEBHOOK_URL');
 
     try {
-        const { from, to } = message;
+        const from = message.headers.get('from');
+        const to = message.headers.get('to');
         const subject = message.headers.get('subject') || '(no subject)';
         const date = new Date().toISOString(); // Current timestamp
         const rawEmail = (await new Response(message.raw).text()).replace(/utf-8/gi, 'utf-8');


### PR DESCRIPTION
It seems that emails are saved in files that use message IDs for their name. This update will rewrite emails in the single file.